### PR TITLE
Add traccc aaS docs 

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -13,6 +13,7 @@ parts:
     chapters:
       - file: example-ExaTrkX
       - file: example-GNN4ITk
+      - file: example-traccc
   - caption: Development
     chapters:
       - file: custom-backend

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -14,6 +14,7 @@ parts:
       - file: example-ExaTrkX
       - file: example-GNN4ITk
       - file: example-traccc
+      - file: example-SuperSONIC-deploy
   - caption: Development
     chapters:
       - file: custom-backend

--- a/book/example-SuperSONIC-deploy.md
+++ b/book/example-SuperSONIC-deploy.md
@@ -1,0 +1,105 @@
+# Deployment on the NRP Nautilus Kubernetes (k8) cluster with `SuperSONIC`
+
+For server-side large-scale deployment we are using the [SuperSONIC](https://fastmachinelearning.org/SuperSONIC/index.html) 
+framework. To begin, clone the repository
+
+```
+git clone git@github.com:fastmachinelearning/SuperSONIC.git
+```
+
+### Deploying the Server
+
+Deploying the server on Nautilus is as easy as sourcing the setup script:
+
+```bash
+source deploy-nautilus-atlas.sh
+```
+
+The settings are defined in `values/values-nautilus-atlas.yaml` files. To select which GPUs to run on, uncomment the appropriate lines of code corresponding to the following possible selections:
+
+```
+    - NVIDIA-A10
+    - NVIDIA-A40
+    - NVIDIA-A100-SXM4-80GB
+    - NVIDIA-L40
+    - NVIDIA-A100-80GB-PCIe
+    - NVIDIA-A100-80GB-PCIe-MIG-1g.10gb
+    - NVIDIA-L4
+    - NVIDIA-A100-PCIE-40GB
+    - NVIDIA-GH200-480GB
+```
+
+```{note}
+To run on A100s at NRP, you have to reserve a time. This can be accomplished at [this link](https://portal.nrp.ai/reservations/)
+```
+
+To load multiple models per GPU, edit the `triton.args` string to:
+
+```
+  args:
+    - |
+      /opt/tritonserver/bin/tritonserver \
+      --model-repository=/traccc-aaS/traccc-aaS/backend/nmodels_<NUMBER_OF_MODELS> \
+      --log-verbose=1 \
+      --exit-on-error=true
+```
+and be sure to replace `<NUMBER_OF_MODELS>` with the number of Triton model instances you'd like to load. By default, this loads one model instance. 
+
+Finally, to run across multiple GPUs, increase or decrease the `replicas: n` where `n` is the number of GPUs to request. This loads one Triton server per GPU with the request number of models you've selected. 
+
+For more information on configuring the server, consult the [SuperSONIC Configuration Guide](https://fastmachinelearning.org/SuperSONIC/configuration-guide.html). 
+
+### Running the client
+
+In order for the client to interface with the server, the location of the server needs to be specified. First, ensure the server is running
+
+```bash
+kubectl get pods -n atlas-sonic
+```
+which has output something like:
+
+```
+NAME                            READY   STATUS    RESTARTS   AGE
+envoy-atlas-7f6d99df88-667jd    1/1     Running   0          86m
+triton-atlas-594f595dbf-n4sk7   1/1     Running   0          86m
+```
+
+or use the [k9s](https://k9scli.io) tool to manage your pods. You can then check everything is healthy with
+
+```bash
+curl -kv https://atlas.nrp-nautilus.io/v2/health/ready
+```
+
+which should produce somewhere in the output the lines:
+
+```
+< HTTP/1.1 200 OK
+< Content-Length: 0
+< Content-Type: text/plain
+```
+
+Then, the client can be run with, for instance:
+
+```bash
+python TracccTritonClient.py -u atlas.nrp-nautilus.io --ssl
+```
+
+To see what's going on from the server side, run
+
+```bash
+kubectl logs triton-atlas-594f595dbf-n4sk7
+```
+
+where `triton-atlas-594f595dbf-n4sk7` is the name of the server found when running the `get pods` command above. 
+
+To run with [`perf_analyzer`](https://docs.nvidia.com/deeplearning/triton-inference-server/archives/triton-inference-server-2280/user-guide/docs/user_guide/perf_analyzer.html) and make plots, consult the [performance repo](https://github.com/milescb/traccc-aaS-performance/tree/main). 
+
+### !!! Important !!!
+
+Make sure to `uninstall` once the server is not needed anymore. 
+
+```bash
+helm uninstall atlas-sonic -n atlas-sonic
+```
+
+Make sure to read the [Policies](https://docs.nationalresearchplatform.org/userdocs/start/policies/) before using Nautilus. 

--- a/book/example-traccc.md
+++ b/book/example-traccc.md
@@ -1,0 +1,90 @@
+# Traccc as-a-Service
+
+Main objective: run [traccc](https://github.com/acts-project/traccc/tree/main) as-a-Service. Getting this working includes creating three main components:
+
+1. a shared library of `traccc` and writing a standalone version with the essential pieces of the code included
+2. a custom backend using the standalone version above to launch the Triton server
+3. a client to send data to the server
+
+A minimal description of how to build a working version is detailed below. For more in-depth descriptions of each step in the process, consult the [git repo](https://github.com/milescb/traccc-aaS) of this project. 
+
+## Running out of the box
+
+### Get the code
+
+Simply clone the repository with 
+
+```
+git clone --recurse-submodules git@github.com:milescb/traccc-aaS.git
+```
+
+### Docker
+
+A docker built for the triton server can be found at `docker.io/milescb/triton-server:latest`. To run this do
+
+```
+shifter --module=gpu --image=milescb/tritonserver:latest
+```
+
+or use your favorite docker application and mount the appropriate directories. 
+
+```{note}
+An image has been built with the custom backend pre-installed at `docker.io/milescb/traccc-aas:v1.1`. To run this, open the image, then run the server with
+
+`tritonserver --model-repository=$MODEL_REPO`
+
+To see how this was built, consult the `Dockerfile` in the [traccc-aaS repository](https://github.com/milescb/traccc-aaS). 
+```
+
+### Shared Library on NERSC
+
+To run out of the box on [NERSC](https://www.nersc.gov), an installation of `traccc` and the backend can be found at `/global/cfs/projectdirs/m3443/data/traccc-aaS/software/prod/ver_09152024/install`. To set up the environment, run the docker then set the following environment variables
+
+```
+export DATADIR=/global/cfs/projectdirs/m3443/data/traccc-aaS/data
+export INSTALLDIR=/global/cfs/projectdirs/m3443/data/traccc-aaS/software/prod/ver_09152024/install
+export PATH=$INSTALLDIR/bin:$PATH
+export LD_LIBRARY_PATH=$INSTALLDIR/lib:$LD_LIBRARY_PATH
+```
+
+Then the server can be launched with 
+
+```
+tritonserver --model-repository=$INSTALLDIR/models
+```
+
+```{note}
+
+If you do not have access to NERSC computing resources, then you will need to build `traccc` from source. Follow the instructions in the [traccc repo](https://github.com/acts-project/traccc/tree/main) then update `INSTALLDIR` and `DATADIR` appropriately. 
+
+To avoid having to build from source, deploy the server with the docker image `docker.io/milescb/tritonserver:latest` as directed above. 
+
+```
+
+## Building the backend
+
+First, enter the docker and set environment variables as documented above. Then run
+
+```
+cd backend/traccc-gpu && mkdir build install && cd build
+cmake -B . -S ../ \
+    -DCMAKE_INSTALL_PREFIX=../install/
+
+cmake --build . --target install -- -j20
+```
+
+Then, the server can be launched as above:
+
+```
+tritonserver --model-repository=../../models
+```
+
+## Run a simple client 
+
+Once the server is launched, run the model via:
+
+```
+cd client && python TracccTritonClient.py 
+```
+
+This launches a simple `gRPC` client which makes one inference request to the deployed server. To test the scalability of the model and obtain performance metrics, the `perf_analyzer` tool can be used. For more information on how to obtain metrics and make plots, consult the [traccc-aaS-performance repository](https://github.com/milescb/traccc-aaS-performance).

--- a/book/example-traccc.md
+++ b/book/example-traccc.md
@@ -14,7 +14,7 @@ A minimal description of how to build a working version is detailed below. For m
 
 Simply clone the repository with 
 
-```
+```bash
 git clone --recurse-submodules git@github.com:milescb/traccc-aaS.git
 ```
 
@@ -22,7 +22,7 @@ git clone --recurse-submodules git@github.com:milescb/traccc-aaS.git
 
 A docker built for the triton server can be found at `docker.io/milescb/triton-server:latest`. To run this do
 
-```
+```bash
 shifter --module=gpu --image=milescb/tritonserver:latest
 ```
 
@@ -40,7 +40,7 @@ To see how this was built, consult the `Dockerfile` in the [traccc-aaS repositor
 
 To run out of the box on [NERSC](https://www.nersc.gov), an installation of `traccc` and the backend can be found at `/global/cfs/projectdirs/m3443/data/traccc-aaS/software/prod/ver_09152024/install`. To set up the environment, run the docker then set the following environment variables
 
-```
+```bash
 export DATADIR=/global/cfs/projectdirs/m3443/data/traccc-aaS/data
 export INSTALLDIR=/global/cfs/projectdirs/m3443/data/traccc-aaS/software/prod/ver_09152024/install
 export PATH=$INSTALLDIR/bin:$PATH
@@ -49,7 +49,7 @@ export LD_LIBRARY_PATH=$INSTALLDIR/lib:$LD_LIBRARY_PATH
 
 Then the server can be launched with 
 
-```
+```bash
 tritonserver --model-repository=$INSTALLDIR/models
 ```
 
@@ -65,7 +65,7 @@ To avoid having to build from source, deploy the server with the docker image `d
 
 First, enter the docker and set environment variables as documented above. Then run
 
-```
+```bash
 cd backend/traccc-gpu && mkdir build install && cd build
 cmake -B . -S ../ \
     -DCMAKE_INSTALL_PREFIX=../install/
@@ -75,7 +75,7 @@ cmake --build . --target install -- -j20
 
 Then, the server can be launched as above:
 
-```
+```bash
 tritonserver --model-repository=../../models
 ```
 
@@ -83,7 +83,7 @@ tritonserver --model-repository=../../models
 
 Once the server is launched, run the model via:
 
-```
+```bash
 cd client && python TracccTritonClient.py 
 ```
 


### PR DESCRIPTION
Added page for getting `traccc` runnings as-a-Service and a page for deploying on NRP. 